### PR TITLE
wrap uncaught exceptions for webclient in SimpleGQLQuery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,17 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.14.6</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Apollo GraphQL -->
         <dependency>

--- a/src/main/java/org/icgc_argo/workflow_graph_lib/workflow/client/RdpcClient.java
+++ b/src/main/java/org/icgc_argo/workflow_graph_lib/workflow/client/RdpcClient.java
@@ -507,6 +507,11 @@ public class RdpcClient {
             clientResponse -> {
               throw new RequeueableException(EX_5XX_ERROR);
             })
-        .bodyToMono(new ParameterizedTypeReference<>() {});
+        .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+        // onErrorMap catches thrown exceptions that are not GraphExceptions (e.g. NetworkTimeout,
+        // SSLException) and wraps them with DeadLetterQueueableException
+        .onErrorMap(
+            throwable -> !(throwable instanceof GraphException),
+            throwable -> new DeadLetterQueueableException(throwable.toString()));
   }
 }

--- a/src/test/java/org/icgc_argo/workflow_graph_lib/workflow/client/SimpleQueryWithEventTests.java
+++ b/src/test/java/org/icgc_argo/workflow_graph_lib/workflow/client/SimpleQueryWithEventTests.java
@@ -1,0 +1,93 @@
+package org.icgc_argo.workflow_graph_lib.workflow.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.net.ssl.SSLContext;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.icgc_argo.workflow_graph_lib.exceptions.DeadLetterQueueableException;
+import org.icgc_argo.workflow_graph_lib.exceptions.RequeueableException;
+import org.icgc_argo.workflow_graph_lib.schema.AnalysisFile;
+import org.icgc_argo.workflow_graph_lib.schema.GraphEvent;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import reactor.test.StepVerifier;
+
+@Slf4j
+class SimpleQueryWithEventTests {
+  private static final String GRAPHQL_PATH = "/graphql";
+  private static MockWebServer mockWebServer;
+
+  private static final GraphEvent MOCK_GRAPH_EVENT =
+      new GraphEvent(
+          UUID.randomUUID().toString(),
+          "NON_EXIST_ANALYSIS_ID",
+          "anAnalysisState",
+          "anAnalysisType",
+          "aStudyId",
+          "aStrategy",
+          List.of("Donor1"),
+          List.of(new AnalysisFile("aFileDataType")));
+
+  @BeforeEach
+  public void beforeEach() {
+    mockWebServer = new MockWebServer();
+  }
+
+  @AfterEach
+  @SneakyThrows
+  public void afterEach() {
+    mockWebServer.close();
+  }
+
+  @Test
+  @SneakyThrows
+  public void test_http200_has_no_error() {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .setBody("{ \"data\": [] }"));
+
+    val url = mockWebServer.url(GRAPHQL_PATH).url().toString();
+    val rdpcClient = new RdpcClient(url);
+
+    val mono = rdpcClient.simpleQueryWithEvent("", MOCK_GRAPH_EVENT);
+
+    StepVerifier.create(mono).expectNext(Map.of("data", List.of())).expectComplete().verify();
+  }
+
+  @Test
+  @SneakyThrows
+  public void test_http401_is_requeueable() {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(401));
+
+    val url = mockWebServer.url(GRAPHQL_PATH).url().toString();
+    val rdpcClient = new RdpcClient(url);
+
+    val mono = rdpcClient.simpleQueryWithEvent("", MOCK_GRAPH_EVENT);
+
+    StepVerifier.create(mono).expectError(RequeueableException.class).verify();
+  }
+
+  @Test
+  @SneakyThrows
+  public void test_network_ssl_exception_handshake_timeout_is_DLQ() {
+    // Setup mockWebServer HTTPS/SSL config to generate "SSLException: handshake timeout" in Webclient
+    val tunnelProxy = true;
+    val sslSocketFactory = SSLContext.getDefault().getSocketFactory();
+    mockWebServer.useHttps(sslSocketFactory, tunnelProxy);
+
+    val url = mockWebServer.url(GRAPHQL_PATH).url().toString();
+    val rdpcClient = new RdpcClient(url);
+
+    val mono = rdpcClient.simpleQueryWithEvent("", MOCK_GRAPH_EVENT);
+
+    StepVerifier.create(mono).expectError(DeadLetterQueueableException.class).verify();
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/icgc-argo/workflow-graph-lib/issues 

Changes:
- Wrap uncaught non GraphExceptions by Webclient with DLQGraphException
- Add tests to verify previous and new functionality
