### PR TITLE
Automation load test issue fix #98

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>workflow-graph-lib</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.11.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library functions used throughout Workflow Graph Components</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>workflow-graph-lib</artifactId>
-    <version>1.11.0</version>
+    <version>1.11.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library functions used throughout Workflow Graph Components</description>


### PR DESCRIPTION
Every thread will now have its own javascript context to avoid issues caused due to multiple threads trying to access a common context.

[Some downstream jobs are not triggered when multiple analysis are published simultaneously. #98](https://app.zenhub.com/workspaces/icgc-argo-platform-dk-production-board-5e542d38415f5034e9fed89d/issues/gh/icgc-argo/workflow-graph-node/98)